### PR TITLE
Pin npm package versions - SOP-1331

### DIFF
--- a/test-engineering/package.json
+++ b/test-engineering/package.json
@@ -8,7 +8,7 @@
   "license": "ISC",
   "description": "",
   "devDependencies": {
-    "@playwright/test": "^1.50.1",
-    "@types/node": "^22.13.5"
+    "@playwright/test": "1.50.1",
+    "@types/node": "22.13.5"
   }
 }


### PR DESCRIPTION
## Package Version Pinning

This PR pins all npm package versions to their currently installed versions as specified in package-lock.json.

**Changes:**
- All dependencies and devDependencies have been locked to exact versions
- Removed version ranges (^, ~, etc.) to ensure reproducible builds
- All packages have been verified to be free of known vulnerabilities

**Related Issue:** SOP-1331 - Pin npm package versions

**Verification:**
- ✅ package-lock.json present
- ✅ No vulnerabilities detected
- ✅ All packages pinned to exact versions